### PR TITLE
Add missing keyword identifiers

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,9 +8,9 @@ Stdinout	KEYWORD1
 # Methods and Functions
 #######################################
 
-open
-close
-getStream
-STDIO
+open	KEYWORD2
+close	KEYWORD2
+getStream	KEYWORD2
+STDIO	KEYWORD2
 
 #######################################


### PR DESCRIPTION
Without these identifiers the keywords are not highlighted by the Arduino IDE.